### PR TITLE
fix: 日記の読み取り時のエラー改修

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -76,3 +76,21 @@ CREATE TABLE IF NOT EXISTS travelogues (
         REFERENCES users(user_id)
         ON DELETE CASCADE
 );
+
+-- =================================================================
+--  サンプルデータの挿入
+-- =================================================================
+
+-- サンプルユーザーの挿入
+INSERT INTO users (email, password) VALUES
+('test@example.com', 'password123')
+ON CONFLICT (email) DO NOTHING;
+
+-- サンプルカテゴリの挿入
+INSERT INTO categories (user_id, name, color) VALUES
+(1, '観光', '#FF6B6B'),
+(1, '食事', '#4ECDC4'),
+(1, '移動', '#45B7D1'),
+(1, '宿泊', '#96CEB4'),
+(1, 'その他', '#FFEAA7')
+ON CONFLICT (user_id, name) DO NOTHING;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     volumes:
       - ../study_abroad_journal_front:/app
     environment:
-      - NEXT_PUBLIC_API_URL=http://backend:8080
+      # - NEXT_PUBLIC_API_URL=http://backend:8080
+      - NEXT_PUBLIC_API_URL=http://localhost:8080
     depends_on:
       - backend
 


### PR DESCRIPTION
ブラウザからbackendホスト名を解決できていなかった．
（また，db/init.sqlにサンプルデータを追加）

 DNS解決エラー

  エラー内容:
  api.ts:28 GET http://backend:8080/api/diaries
  net::ERR_NAME_NOT_RESOLVED

  原因:
  - docker-compose.ymlの環境変数でNEXT_PUBLIC_API_URL=http://b
  ackend:8080が設定されていたが、ブラウザからはbackendホスト名
  を解決できない

  解消方法:
  - docker-compose.ymlの環境変数をhttp://localhost:8080に変更